### PR TITLE
Feature [Dashboard] - adding the listQuery for comments

### DIFF
--- a/www/Controllers/Base.php
+++ b/www/Controllers/Base.php
@@ -5,6 +5,7 @@ namespace App;
 use App\Core\View;
 use App\Core\Security;
 use App\Core\Statistic;
+use App\Core\ListQuery;
 
 
 class Base{
@@ -18,21 +19,21 @@ class Base{
 
 		$statisticsPages = Statistic::getSimpleStatistics(
 			[
-				'Page' => [
+				[
 					'label' => 'Page visibles',
 					'element' => 'Page',
 					'filter' => [
 						'isVisible' => 1
 					]
 				],
-				'Article' => [
+				[
 					'label' => 'Articles visibles',
 					'element' => 'Article',
 					'filter' => [
 						'isVisible' => 1
 					]
 				],
-				'Comment' => [
+				[
 					'label' => 'Commentaires postés',
 					'element' => 'Comment',
 					'filter' => []
@@ -40,9 +41,31 @@ class Base{
 			]
 		);
 
+		$listComments = ListQuery::getSimpleList(
+			[
+				'element' => 'Comment',
+				'columns' => [
+					'id_User' => [
+						'label' => 'Utilisateurs',
+						'size' => 2,
+						'combo' => [
+							'element' => 'User',
+							'columns' => ['firstname', 'lastname'],
+							'filterKey' => 'id'
+						]
+					],
+					'content' => [
+						'label' => 'Commentaires',
+						'size' => 3
+					],
+				]
+			]
+		);
+
 		//Affiche moi la vue dashboard;
 		$view = new View("dashboard", "back");
 		$view->assign("statistics", $statisticsPages);
+		$view->assign("comments", $listComments);
 	}
 
 }

--- a/www/Core/ListQuery.php
+++ b/www/Core/ListQuery.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Core;
+
+class ListQuery
+{
+    public static function getSimpleList($elementQuery) {
+        $legendHtml = '<li class="legend">';
+
+        $elementClass = "App\\Models\\".$elementQuery['element'];
+            
+        if (class_exists($elementClass)){
+            $entity = new $elementClass;
+
+            $resultsQuery = $entity->query(array_keys($elementQuery['columns']));
+        }else {
+            return [];
+        }
+
+        $resultsList = [];
+
+        foreach ($resultsQuery as $keyResult => $result) {
+            $index = 0;
+            $resultHtml = '<li class="listItem">';
+
+            foreach ($elementQuery['columns'] as $keyColumn => $column) {
+                if ($keyResult === 0){
+                    $legendHtml .= '<p class="flex-weight-'.($column['size'] ? $column['size'] : 1).'">'.$column['label'].'</p>';
+                }
+
+                if (array_key_exists('combo', $column)){
+                    $elementClass = "App\\Models\\".$column['combo']['element'];
+
+                    if (class_exists($elementClass)){
+                        $entity = new $elementClass;
+            
+                        $resultCombo = $entity->query(
+                            $column['combo']['columns'], 
+                            [
+                                $column['combo']['filterKey'] => $result[$index]
+                            ]
+                        )[0];
+
+                        $resultComboString = [];
+                        
+                        foreach ($column['combo']['columns'] as $comboColumn) {
+                            array_push($resultComboString, $resultCombo[$comboColumn]);
+                        } 
+                        
+                        $resultHtml .= '<p class="flex-weight-'.($column['size'] ? $column['size'] : 1).'">'
+                                .implode(' ', $resultComboString)
+                            .'</p>';
+                    }
+                }else {
+                    $resultHtml .= '<p class="flex-weight-'.($column['size'] ? $column['size'] : 1).'">'
+                            .$result[$index]
+                        .'</p>';
+                }
+                $index ++;
+            }
+            $resultHtml .= '</li>';
+            array_push($resultsList, $resultHtml);
+        }
+
+        $legendHtml .= '</li>';
+
+        return array_merge([$legendHtml], $resultsList);
+    }
+}

--- a/www/Views/dashboard_view.php
+++ b/www/Views/dashboard_view.php
@@ -194,66 +194,16 @@
 <section class="col-12" style="grid-column: 9 / 13; grid-row: 2 / 4;">
     <h1 class="titleSection"><img src=<?php App\Core\View::getAssets("icons/icon_comment.png")?> alt="">Commentaires</h1>
     <ul class="listItemComplete limit-height-375"  style="min-height: 80%;">
-        <li class="legend">
-            <p class="flex-weight-1">Utilisateurs</p>
-            <p class="flex-weight-1">Titres</p>
-            <p></p>
-        </li>
+        <?php foreach ($comments as $key => $comment) {
+                echo $comment;
+            }?>
+        <!--
         <li class="listItem">
             <p class="flex-weight-1">Contact</p>
             <p class="flex-weight-1 status-color-important">Affichage</p>
             <p></p>
         </li>
-        <li class="listItem">
-            <p class="flex-weight-1">Hôtel de Marseille</p>
-            <p class="flex-weight-1 status-color-normal">Réservation</p>
-            <p></p>
-        </li>
-        <li class="listItem">
-            <p class="flex-weight-1">Accueil</p>
-            <p class="flex-weight-1 status-color-moyen">Affichage</p>
-            <p></p>
-        </li>
-        <li class="listItem">
-            <p class="flex-weight-1">Configuration URL</p>
-            <p class="flex-weight-1 status-color-important">Configuration</p>
-            <p></p>
-        </li>
-        <li class="listItem">
-            <p class="flex-weight-1">Contact</p>
-            <p class="flex-weight-1 status-color-important">Affichage</p>
-            <p></p>
-        </li>
-        <li class="listItem">
-            <p class="flex-weight-1">Hôtel de Marseille</p>
-            <p class="flex-weight-1 status-color-normal">Réservation</p>
-            <p></p>
-        </li>
-        <li class="listItem">
-            <p class="flex-weight-1">Accueil</p>
-            <p class="flex-weight-1 status-color-moyen">Affichage</p>
-            <p></p>
-        </li>
-        <li class="listItem">
-            <p class="flex-weight-1">Configuration URL</p>
-            <p class="flex-weight-1 status-color-important">Configuration</p>
-            <p></p>
-        </li>
-        <li class="listItem">
-            <p class="flex-weight-1">Contact</p>
-            <p class="flex-weight-1 status-color-important">Affichage</p>
-            <p></p>
-        </li>
-        <li class="listItem">
-            <p class="flex-weight-1">Hôtel de Marseille</p>
-            <p class="flex-weight-1 status-color-normal">Réservation</p>
-            <p></p>
-        </li>
-        <li class="listItem">
-            <p class="flex-weight-1">Hôtel de Marseille</p>
-            <p class="flex-weight-1 status-color-normal">Réservation</p>
-            <p></p>
-        </li>
+        -->
     </ul>
     <div class="d-flex callToActionContainer">
         <button class="callToAction-withIcon">


### PR DESCRIPTION
## Dashboard - adding the listQuery

Core/ListQuery can be used to simply create lists.
By example, you can ask the list of the User and the Comments using the static function ListQuery::getSimpleList($elements)

ListQuery::getSimpleList(
			[
				'element' => 'Comment',
				'columns' => [
					'id_User' => [
						'label' => 'Utilisateurs',
						'size' => 2,
						'combo' => [
							'element' => 'User',
							'columns' => ['firstname', 'lastname'],
							'filterKey' => 'id'
						]
					],
					'content' => [
						'label' => 'Commentaires',
						'size' => 3
					],
				]
			]
		);