### PR TITLE
Feature [Security] - fix uri always accepted

### DIFF
--- a/www/Core/Security.php
+++ b/www/Core/Security.php
@@ -12,7 +12,7 @@ class Security
 	private static $_instance = null;
     private static $_userConnectedId = null;
     private static $_actualUri;
-    private static $_alwaysAuthorizedUri = ['/login'];
+    private static $_alwaysAuthorizedUri = ['/login', '/admin/dashboard'];
 
 	private function __construct($_userConnectedId) {
         self::$_userConnectedId = $_userConnectedId;
@@ -28,7 +28,8 @@ class Security
     }
 
     public static function isAuthorized($uri) {
-        if (in_array('/login', self::$_alwaysAuthorizedUri)) return true;
+        if (in_array($uri, self::$_alwaysAuthorizedUri)) return true;
+
         self::$_actualUri = $uri;
         $user = new User();
         $role = new Role();
@@ -38,7 +39,7 @@ class Security
             ["id" => $user->getRole()]
         );
         $perms = json_decode($result[0]['value'], true);
-        if (array_key_exists($uri, $perms) || array_key_exists("all_perms", $perms) || $uri == "/admin/dashboard") {
+        if (array_key_exists($uri, $perms) || array_key_exists("all_perms", $perms)) {
             // TODO Redirection à faire autre part que /dashboard
             return true;
         }


### PR DESCRIPTION
## Fixtures

/login and /admin/dashboard are always accepted by the roles.
This fix concern the Core\Security class.